### PR TITLE
typo?

### DIFF
--- a/src/THREE.ConstantSpline.js
+++ b/src/THREE.ConstantSpline.js
@@ -91,7 +91,7 @@ THREE.ConstantSpline.prototype.calculateDistances = function() {
 THREE.ConstantSpline.prototype.reticulate = function( settings ) {
 
 	if( this.distancesNeedUpdate ) {
-		s.calculateDistances();
+		this.calculateDistances();
 		this.distancesNeedUpdate = false;
 	}
 


### PR DESCRIPTION
Shouldn't that line be this.calculateDistances(), not s.calculateDistances()?
